### PR TITLE
use latest rdoc, eg 3.12 instead strictly stick to 3.8

### DIFF
--- a/plugin/ri_vim.rb
+++ b/plugin/ri_vim.rb
@@ -2,7 +2,7 @@
 # Modified by Daniel Choi <dhchoi@gmail.com>
 # Modified the RDocRI::Driver class from the original RDoc gem for rdoc_vim gem
 
-gem 'rdoc', '= 3.8'
+gem 'rdoc', '~> 3.8'
 require 'abbrev'
 require 'optparse'
 begin


### PR DESCRIPTION
I have installed rdoc 3.12 and when use plugin instead of result I see load error. 
You should allow users use latest rdoc.
