### PR TITLE
As I discussed in my issue in the old repo...

### DIFF
--- a/plugin/ri.vim
+++ b/plugin/ri.vim
@@ -24,7 +24,10 @@ function! s:runCommand(command)
 endfunction
 
 function! RIVimStatusLine()
-  let a = g:mapleader
+  let a = "\\"
+  if exists("g:mapleader")
+    let a = g:mapleader
+  endif
   return "%<%f\ | Press ".a."? for help "."%r%=%-14.(%l,%c%V%)\ %P"
 endfunction
 


### PR DESCRIPTION
This function is trying to get the value of <Leader> in a variable
to display to the user in the status line.  Seems that unless set
by user in vimrc, Vim doesn't register g:mapleader.  Assume '\' as
that is the default (on Linux and other *nix's; I can't speak for Mac)
