### PR TITLE
rdoc gem version require

### DIFF
--- a/plugin/ri_vim.rb
+++ b/plugin/ri_vim.rb
@@ -2,7 +2,7 @@
 # Modified by Daniel Choi <dhchoi@gmail.com>
 # Modified the RDocRI::Driver class from the original RDoc gem for rdoc_vim gem
 
-gem 'rdoc', '=> 3.8'
+gem 'rdoc', '>=3.8'
 require 'abbrev'
 require 'optparse'
 begin


### PR DESCRIPTION
I don't known why but `gem 'rdoc', '=> 3.8'` stopped working for me on `ruby-2.0.0-p247`. I change it to `gem 'rdoc', '>=3.8'` and it work fine now.
