### PR TITLE
Allow user to skip the default mappings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ this to your `.vimrc`:
     nnoremap  ,RI :call ri#OpenSearchPrompt(1)<cr> " vertical split
     nnoremap  ,RK :call ri#LookupNameUnderCursor()<cr> " keyword lookup
 
+Alternatively you can also disable the default plugin mappings to set your own:
+
+    let g:ri_no_mappings=1
 
 ## Maintainers
 

--- a/plugin/ri.vim
+++ b/plugin/ri.vim
@@ -341,12 +341,10 @@ function! s:updateBrowserBufNrAndLoadSyntax()
 endfunction
 
 
-if get(g:, 'ri_no_mappings')
-  if !hasmapto("ri#OpenSearchPrompt",'n')
-    nnoremap <silent> <leader>r :call ri#OpenSearchPrompt(0)<cr>
-    nnoremap <silent> <leader>R :call ri#OpenSearchPrompt(1)<cr>
-    nnoremap <silent> <leader>K :call ri#LookupNameUnderCursor()<cr>
-  endif
+if get(g:, 'ri_no_mappings') && !hasmapto("ri#OpenSearchPrompt",'n')
+  nnoremap <silent> <leader>r :call ri#OpenSearchPrompt(0)<cr>
+  nnoremap <silent> <leader>R :call ri#OpenSearchPrompt(1)<cr>
+  nnoremap <silent> <leader>K :call ri#LookupNameUnderCursor()<cr>
 endif
 
 autocmd BufRead *.rivim call <SID>updateBrowserBufNrAndLoadSyntax()

--- a/plugin/ri.vim
+++ b/plugin/ri.vim
@@ -341,7 +341,7 @@ function! s:updateBrowserBufNrAndLoadSyntax()
 endfunction
 
 
-if get(g:, 'ri_no_mappings') && !hasmapto("ri#OpenSearchPrompt",'n')
+if !get(g:, 'ri_no_mappings') && !hasmapto("ri#OpenSearchPrompt",'n')
   nnoremap <silent> <leader>r :call ri#OpenSearchPrompt(0)<cr>
   nnoremap <silent> <leader>R :call ri#OpenSearchPrompt(1)<cr>
   nnoremap <silent> <leader>K :call ri#LookupNameUnderCursor()<cr>

--- a/plugin/ri.vim
+++ b/plugin/ri.vim
@@ -341,10 +341,12 @@ function! s:updateBrowserBufNrAndLoadSyntax()
 endfunction
 
 
-if !hasmapto("ri#OpenSearchPrompt",'n')
-  nnoremap <silent> <leader>r :call ri#OpenSearchPrompt(0)<cr>
-  nnoremap <silent> <leader>R :call ri#OpenSearchPrompt(1)<cr>
-  nnoremap <silent> <leader>K :call ri#LookupNameUnderCursor()<cr>
+if get(g:, 'ri_no_mappings')
+  if !hasmapto("ri#OpenSearchPrompt",'n')
+    nnoremap <silent> <leader>r :call ri#OpenSearchPrompt(0)<cr>
+    nnoremap <silent> <leader>R :call ri#OpenSearchPrompt(1)<cr>
+    nnoremap <silent> <leader>K :call ri#LookupNameUnderCursor()<cr>
+  endif
 endif
 
 autocmd BufRead *.rivim call <SID>updateBrowserBufNrAndLoadSyntax()


### PR DESCRIPTION
Fixes https://github.com/danchoi/ri.vim/issues/10.

This is useful because most people set their mappings after plugins are loaded and prefer to not edit plugins by hand.