### PR TITLE
Fix NoMethodError for File.exists?

### DIFF
--- a/plugin/ri_vim.rb
+++ b/plugin/ri_vim.rb
@@ -48,7 +48,7 @@ class RIVim
                          options[:use_home],
                          options[:use_gems],
                          *options[:extra_doc_dirs]) do |path, type|
-      if File.exists?(path)
+      if File.exist?(path)
         @doc_dirs << path
         store = RDoc::RI::Store.new path, type
         store.load_cache


### PR DESCRIPTION
Using ruby 3.2, `File.exists?` is no longer a method. Replacing with `File.exist?` fixes it.

After waiting over a year, this fork appears to be inactive. I've fixed it on [my fork](https://github.com/evanthegrayt/ri.vim) if anyone uses this plugin.

Closes #35 